### PR TITLE
fix(issue-282): Flaky Test

### DIFF
--- a/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClient.kt
+++ b/src/main/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClient.kt
@@ -67,7 +67,6 @@ private constructor(
 
     fun deliverCargo(cargoes: Iterable<CargoDeliveryRequest>): Flow<String> {
         if (cargoes.none()) return emptyFlow()
-
         var deliveryObserver: StreamObserver<CargoDelivery>? = null
         val cargoesToAck = mutableListOf<String>()
         val ackChannel = BroadcastChannel<String>(1)
@@ -84,6 +83,7 @@ private constructor(
 
             override fun onError(t: Throwable) {
                 logger.log(Level.WARNING, "Ending deliverCargo due to ack error", t)
+                println("\"Ending deliverCargo due to ack error\", ${t.stackTrace}")
                 ackChannel.close(CogRPCException(t))
                 deliveryObserver?.onCompleted()
             }

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientTest.kt
@@ -65,14 +65,12 @@ internal class CogRPCClientTest {
                 }
             }
 
-            val ackFlow = client.deliverCargo(listOf(cargo)).take(1)
+            val ackFlow = client.deliverCargo(listOf(cargo))
 
             assertEquals(
                 cargo.localId,
                 ackFlow.first()
             )
-
-            waitFor { isComplete }
 
             client.close()
             testServer?.stop()

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -64,13 +65,14 @@ internal class CogRPCClientTest {
                 }
             }
 
-            val ackFlow = client.deliverCargo(listOf(cargo)).first()
-            waitFor { isComplete }
+            val ackFlow = client.deliverCargo(listOf(cargo)).take(1)
 
             assertEquals(
                 cargo.localId,
-                ackFlow
+                ackFlow.first()
             )
+
+            waitFor { isComplete }
 
             client.close()
             testServer?.stop()

--- a/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientTest.kt
+++ b/src/test/kotlin/tech/relaycorp/relaynet/cogrpc/client/CogRPCClientTest.kt
@@ -64,14 +64,13 @@ internal class CogRPCClientTest {
                 }
             }
 
-            val ackFlow = client.deliverCargo(listOf(cargo))
+            val ackFlow = client.deliverCargo(listOf(cargo)).first()
+            waitFor { isComplete }
 
             assertEquals(
                 cargo.localId,
-                ackFlow.first()
+                ackFlow
             )
-
-            waitFor { isComplete }
 
             client.close()
             testServer?.stop()


### PR DESCRIPTION
# What kind of change does this PR introduce?
 
Flaky test "fix"

# Other information
Currently we are using `ackFlow.first()`, underneath it uses `collectWhile`.
`take(1)` is not written via collectWhile on purpose. It checks the condition first and then makes a tail-call to either emit or emitAbort. Since my search was finding that it was the .first() resulting in the flaky and that it can only be empty on this test if there is some sort of unverseen "flaky" error inside `CargoRelayGrpc.newStub`, I am trying to use to force its hand... 